### PR TITLE
fix(isl): requires types to have a name

### DIFF
--- a/isl/schema.isl
+++ b/isl/schema.isl
@@ -34,18 +34,28 @@ type::{
   type: document,
   ordered_elements: [
     { type: schema_header, occurs: optional },
-    { type: $non_type, occurs: range::[0, max] },
-    { type: type, occurs: range::[0, max] },
-    { type: $non_type, occurs: range::[0, max] },
+    { type: type_or_$non_isl, occurs: range::[0, max] },
     { type: schema_footer, occurs: optional },
   ],
 }
 
 type::{
-  name: $non_type,
+  name: type_or_$non_isl,
+  one_of: [
+    type,
+    $non_isl,
+  ],
+}
+
+type::{
+  name: $non_isl,
   type: $any,
   not: {
-    annotations: required::[type],
+    one_of: [
+      { annotations: required::[schema_header] },
+      { annotations: required::[type] },
+      { annotations: required::[schema_footer] },
+    ],
   },
 }
 

--- a/isl/schema.isl
+++ b/isl/schema.isl
@@ -34,11 +34,19 @@ type::{
   type: document,
   ordered_elements: [
     { type: schema_header, occurs: optional },
-    { type: $any, occurs: range::[0, max] },
+    { type: $non_type, occurs: range::[0, max] },
     { type: type, occurs: range::[0, max] },
-    { type: $any, occurs: range::[0, max] },
+    { type: $non_type, occurs: range::[0, max] },
     { type: schema_footer, occurs: optional },
   ],
+}
+
+type::{
+  name: $non_type,
+  type: $any,
+  not: {
+    annotations: required::[type],
+  },
 }
 
 schema_footer::{

--- a/isl/type.isl
+++ b/isl/type.isl
@@ -54,7 +54,7 @@ type::{
   type: type_inline,
   annotations: required::[type],
   fields: {
-    name: symbol,
+    name: { type: symbol, occurs: required },
   },
 }
 


### PR DESCRIPTION
Related to https://github.com/amzn/ion-schema-kotlin/issues/139.

* the `type` type now requires a `name` field
* also:  definition and use of `$non_isl` prevents an unnamed `type::` (or a `schema_header::` or `schema_footer::`) from being treated as open content (and thereby not invalid).  Also now allows for open content to occur before, after, and between a schema's type definitions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
