### PR TITLE
adding schema for utf8_byte_length constraint

### DIFF
--- a/isl/type.isl
+++ b/isl/type.isl
@@ -12,6 +12,7 @@ schema_header::{
     { id: "isl/scale.isl",               type: scale },
     { id: "isl/timestamp_offset.isl",    type: timestamp_offset },
     { id: "isl/timestamp_precision.isl", type: timestamp_precision },
+    { id: "isl/utf8_byte_length.isl",    type: utf8_byte_length },
     { id: "isl/valid_values.isl",        type: valid_values },
   ],
 }
@@ -45,6 +46,7 @@ type::{
     timestamp_offset:    timestamp_offset,
     timestamp_precision: timestamp_precision,
     type:                type_reference,
+    utf8_byte_length:    utf8_byte_length,
     valid_values:        valid_values,
   },
 }

--- a/isl/utf8_byte_length.isl
+++ b/isl/utf8_byte_length.isl
@@ -1,0 +1,16 @@
+ schema_header::{
+   imports: [
+     { id: "isl/non_negative_int.isl" },
+   ],
+ }
+
+ type::{
+   name: utf8_byte_length,
+   one_of: [
+     non_negative_int,
+     range_non_negative_int,
+   ],
+ }
+
+ schema_footer::{
+ }


### PR DESCRIPTION
*Description of changes:*
This PR adds schema for `utf8_byte_length` constraint. 

Related PR: https://github.com/amzn/ion-schema-kotlin/pull/162 