### PR TITLE
Distinguishes between top-level types and inline types

### DIFF
--- a/isl/type.isl
+++ b/isl/type.isl
@@ -23,7 +23,7 @@ type::{
 }
 
 type::{
-  name: type_inline,
+  name: constraint_bag,
   type: struct,
   fields: {
     all_of:              list_of_type_references,
@@ -52,8 +52,16 @@ type::{
 }
 
 type::{
+  name: type_inline,
+  type: constraint_bag,
+  fields: {
+    name: nothing,
+  },
+}
+
+type::{
   name: type,
-  type: type_inline,
+  type: constraint_bag,
   annotations: required::[type],
   fields: {
     name: { type: symbol, occurs: required },


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Updates `ion-schema-schemas` to reflect the clarification made in https://github.com/amzn/ion-schema/pull/40. Given that people _could be_ using ISL for ISL, I made the changes in a way that preserves the existing type names, even though the type names in the ISL here don't quite match the names in the grammar.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
