### PR TITLE
Fixes for `schema` and `annotations` ISL for ISL types

### DIFF
--- a/isl/annotations.isl
+++ b/isl/annotations.isl
@@ -8,6 +8,6 @@ type::{
   name: annotations,
   type: list,
   element: annotation,
-  annotations: [optional, required],
+  annotations: [ordered, required, closed],
 }
 

--- a/isl/schema.isl
+++ b/isl/schema.isl
@@ -33,9 +33,13 @@ type::{
   name: schema,
   type: document,
   ordered_elements: [
+    { type: $non_isl, occurs: range::[0, max] },
+    { valid_values: [$ion_schema_1_0], occurs: optional },
+    { type: $non_isl, occurs: range::[0, max] },
     { type: schema_header, occurs: optional },
     { type: type_or_$non_isl, occurs: range::[0, max] },
     { type: schema_footer, occurs: optional },
+    { type: $non_isl, occurs: range::[0, max] },
   ],
 }
 


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

* Add `closed` annotation to `annotations` constraint ISL. Also replace incorrect `optional` with `ordered`.
* Fix `schema` `ordered_elements` to allow open content and the ISL 1.0 version marker.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
