### PR TITLE
Refactors ISL for ISL to support multiple ISL versions

### DIFF
--- a/isl/README.md
+++ b/isl/README.md
@@ -1,12 +1,21 @@
 ## Ion Schema Language (ISL)
 
-Sometimes referred to as "ISL for ISL," the schema defined by the files
-in this folder can be used to validate other schemas expressed in ISL.
-Note that this schema cannot identify all ISL violations (for example,
-validating that a regex constraint is specified with a valid regex string
-is beyond the scope of this schema).
+Sometimes referred to as "ISL for ISL," the schema defined by the files in this folder can be used to validate other schemas expressed in ISL.
+Note that this schema cannot identify all ISL violations.
+For example, validating that a regex constraint is specified with a valid regex string is beyond the scope of this schema.
 
-All schema ids specified here are of the form `isl/<filename>.isl`.
-To determine whether a document conforms, validate it using the
-`schema` type found in `isl/schema.isl`.
+The organization of constituent parts for each ISL schema version may vary.
+However, for every Ion Schema version, there will be a schema id in the form `isl/<ion-schema-version>.isl`.
+This schema file will expose the definitions for certain core Ion Schema types—`schema`, `schema_header`, `schema_footer`, `named_type_definition`, and `inline_type_definition`.
 
+For example, to determine whether something is a valid Ion Schema 2.0 document, you would load the `isl/ion_schema_2_0.isl` schema and validate using the `schema` type.
+
+In addition, `ion-schema-schemas` provides multi-version ISL types.
+The schema `isl/ion_schema.isl` provides core Ion Schema types that are a union of all versions of Ion Schema.
+
+A word of caution—you must assume that any multi-version ISL types will change at some point in the future.
+Any changes to multi-version types will strictly increase the permissiveness of the type.
+However, that does not guarantee that the change will be backwards compatible _for your use case_.
+
+For backwards compatibility for consumers who were using `ion-schema-schemas` by way of `ion-schema-kotlin` prior to the introduction of Ion Schema 2.0, the Ion Schema 1.0 schema definition also appears in the `isl` folder.
+No libraries should take a new dependency on these schema files—they will be removed at some point in the future.

--- a/isl/ion_schema.isl
+++ b/isl/ion_schema.isl
@@ -1,0 +1,36 @@
+$ion_schema_1_0
+
+type::{
+  name: schema,
+  any_of: [
+    { id: "isl/ion_schema_1_0.isl", type: schema },
+  ]
+}
+
+type::{
+  name: schema_header,
+  any_of: [
+    { id: "isl/ion_schema_1_0.isl", type: schema_header },
+  ]
+}
+
+type::{
+  name: named_type_definition,
+  any_of: [
+    { id: "isl/ion_schema_1_0.isl", type: named_type_definition },
+  ]
+}
+
+type::{
+  name: inline_type_definition,
+  any_of: [
+    { id: "isl/ion_schema_1_0.isl", type: inline_type_definition },
+  ]
+}
+
+type::{
+  name: schema_footer,
+  any_of: [
+    { id: "isl/ion_schema_1_0.isl", type: schema_footer },
+  ]
+}

--- a/isl/ion_schema_1_0.isl
+++ b/isl/ion_schema_1_0.isl
@@ -1,0 +1,26 @@
+$ion_schema_1_0
+
+type::{
+  name: schema,
+  type: { id: "isl/ion_schema_1_0/schema.isl", type: schema }
+}
+
+type::{
+  name: schema_header,
+  type: { id: "isl/ion_schema_1_0/schema.isl", type: schema_header }
+}
+
+type::{
+  name: named_type_definition,
+  type: { id: "isl/ion_schema_1_0/type.isl", type: type }
+}
+
+type::{
+  name: inline_type_definition,
+  type: { id: "isl/ion_schema_1_0/type.isl", type: type_inline }
+}
+
+type::{
+  name: schema_footer,
+  type: { id: "isl/ion_schema_1_0/schema.isl", type: schema_footer }
+}

--- a/isl/ion_schema_1_0/annotations.isl
+++ b/isl/ion_schema_1_0/annotations.isl
@@ -1,0 +1,12 @@
+type::{
+  name: annotation,
+  type: symbol,
+  annotations: [optional, required],
+}
+
+type::{
+  name: annotations,
+  type: list,
+  element: annotation,
+  annotations: [ordered, required, closed],
+}

--- a/isl/ion_schema_1_0/byte_length.isl
+++ b/isl/ion_schema_1_0/byte_length.isl
@@ -1,0 +1,16 @@
+schema_header::{
+  imports: [
+    { id: "isl/ion_schema_1_0/non_negative_int.isl" },
+  ],
+}
+
+type::{
+  name: byte_length,
+  one_of: [
+    non_negative_int,
+    range_non_negative_int,
+  ],
+}
+
+schema_footer::{
+}

--- a/isl/ion_schema_1_0/codepoint_length.isl
+++ b/isl/ion_schema_1_0/codepoint_length.isl
@@ -1,0 +1,16 @@
+schema_header::{
+  imports: [
+    { id: "isl/ion_schema_1_0/non_negative_int.isl" },
+  ],
+}
+
+type::{
+  name: codepoint_length,
+  one_of: [
+    non_negative_int,
+    range_non_negative_int,
+  ],
+}
+
+schema_footer::{
+}

--- a/isl/ion_schema_1_0/container_length.isl
+++ b/isl/ion_schema_1_0/container_length.isl
@@ -1,0 +1,16 @@
+schema_header::{
+  imports: [
+    { id: "isl/ion_schema_1_0/non_negative_int.isl" },
+  ],
+}
+
+type::{
+  name: container_length,
+  one_of: [
+    non_negative_int,
+    range_non_negative_int,
+  ],
+}
+
+schema_footer::{
+}

--- a/isl/ion_schema_1_0/contains.isl
+++ b/isl/ion_schema_1_0/contains.isl
@@ -1,0 +1,4 @@
+type::{
+  name: contains,
+  type: list,
+}

--- a/isl/ion_schema_1_0/content.isl
+++ b/isl/ion_schema_1_0/content.isl
@@ -1,0 +1,4 @@
+type::{
+  name: content,
+  valid_values: [closed],
+}

--- a/isl/ion_schema_1_0/non_negative_int.isl
+++ b/isl/ion_schema_1_0/non_negative_int.isl
@@ -1,0 +1,22 @@
+type::{
+  name: non_negative_int,
+  type: int,
+  valid_values: range::[0, max],
+}
+
+type::{
+  name: range_boundary_non_negative_int,
+  type: non_negative_int,
+  annotations: [exclusive],
+}
+
+type::{
+  name: range_non_negative_int,
+  type: list,
+  annotations: required::[range],
+  ordered_elements: [
+    { one_of: [ range_boundary_non_negative_int, { valid_values: [min] } ] },
+    { one_of: [ range_boundary_non_negative_int, { valid_values: [max] } ] },
+  ],
+  container_length: 2,
+}

--- a/isl/ion_schema_1_0/occurs.isl
+++ b/isl/ion_schema_1_0/occurs.isl
@@ -1,0 +1,17 @@
+schema_header::{
+  imports: [
+    { id: "isl/ion_schema_1_0/non_negative_int.isl" },
+  ],
+}
+
+type::{
+  name: occurs,
+  one_of: [
+    non_negative_int,
+    range_non_negative_int,
+    { valid_values: [optional, required] },
+  ],
+}
+
+schema_footer::{
+}

--- a/isl/ion_schema_1_0/precision.isl
+++ b/isl/ion_schema_1_0/precision.isl
@@ -1,0 +1,41 @@
+schema_header::{
+}
+
+type::{
+  name: positive_int,
+  type: int,
+  valid_values: range::[1, max],
+}
+
+type::{
+  name: range_boundary_positive_int,
+  type: positive_int,
+  annotations: [exclusive],
+}
+
+type::{
+  name: range_positive_int,
+  type: list,
+  annotations: required::[range],
+  ordered_elements: [
+    { one_of: [ range_boundary_positive_int, { valid_values: [min] } ] },
+    { one_of: [ range_boundary_positive_int, { valid_values: [max] } ] },
+  ],
+  container_length: 2,
+}
+
+type::{
+  name: range_or_exact_positive_int,
+  one_of: [
+    positive_int,
+    range_positive_int,
+  ],
+}
+
+type::{
+  name: precision,
+  type: range_or_exact_positive_int,
+}
+
+schema_footer::{
+}

--- a/isl/ion_schema_1_0/regex.isl
+++ b/isl/ion_schema_1_0/regex.isl
@@ -1,0 +1,5 @@
+type::{
+  name: regex,
+  type: string,
+  annotations: [i, m],
+}

--- a/isl/ion_schema_1_0/scale.isl
+++ b/isl/ion_schema_1_0/scale.isl
@@ -1,0 +1,16 @@
+schema_header::{
+  imports: [
+    { id: "isl/ion_schema_1_0/non_negative_int.isl" },
+  ],
+}
+
+type::{
+  name: scale,
+  one_of: [
+    non_negative_int,
+    range_non_negative_int,
+  ],
+}
+
+schema_footer::{
+}

--- a/isl/ion_schema_1_0/schema.isl
+++ b/isl/ion_schema_1_0/schema.isl
@@ -1,0 +1,67 @@
+schema_header::{
+  imports: [
+    { id: "isl/ion_schema_1_0/type.isl" },
+  ],
+}
+
+type::{
+  name: import,
+  type: struct,
+  fields: {
+    id: { type: string, occurs: required },
+    type: symbol,
+    as: symbol,
+  },
+}
+
+type::{
+  name: schema_header,
+  type: struct,
+  annotations: required::[schema_header],
+  fields: {
+    imports: { type: list, element: import },
+  },
+}
+
+type::{
+  name: schema_footer,
+  type: struct,
+  annotations: required::[schema_footer],
+}
+
+type::{
+  name: schema,
+  type: document,
+  ordered_elements: [
+    { type: $non_isl, occurs: range::[0, max] },
+    { valid_values: [$ion_schema_1_0], occurs: optional },
+    { type: $non_isl, occurs: range::[0, max] },
+    { type: schema_header, occurs: optional },
+    { type: type_or_$non_isl, occurs: range::[0, max] },
+    { type: schema_footer, occurs: optional },
+    { type: $non_isl, occurs: range::[0, max] },
+  ],
+}
+
+type::{
+  name: type_or_$non_isl,
+  one_of: [
+    type,
+    $non_isl,
+  ],
+}
+
+type::{
+  name: $non_isl,
+  type: $any,
+  not: {
+    one_of: [
+      { annotations: required::[schema_header] },
+      { annotations: required::[type] },
+      { annotations: required::[schema_footer] },
+    ],
+  },
+}
+
+schema_footer::{
+}

--- a/isl/ion_schema_1_0/timestamp_offset.isl
+++ b/isl/ion_schema_1_0/timestamp_offset.isl
@@ -1,0 +1,8 @@
+type::{
+  name: timestamp_offset,
+  type: list,
+  element: {
+    type: string,
+    regex: "^[+|-][0-2][0-9]:[0-5][0-9]$",
+  },
+}

--- a/isl/ion_schema_1_0/timestamp_precision.isl
+++ b/isl/ion_schema_1_0/timestamp_precision.isl
@@ -1,0 +1,39 @@
+schema_header::{
+}
+
+type::{
+  name: timestamp_precision_value,
+  type: symbol,
+  valid_values: [
+    year,
+    month,
+    day,
+    minute,
+    second,
+    millisecond,
+    microsecond,
+    nanosecond,
+  ],
+}
+
+type::{
+  name: range_timestamp_precision_value,
+  type: list,
+  annotations: required::[range],
+  ordered_elements: [
+    { one_of: [ timestamp_precision_value, { valid_values: [min] } ] },
+    { one_of: [ timestamp_precision_value, { valid_values: [max] } ] },
+  ],
+  container_length: 2,
+}
+
+type::{
+  name: timestamp_precision,
+  one_of: [
+    timestamp_precision_value,
+    range_timestamp_precision_value,
+  ],
+}
+
+schema_footer::{
+}

--- a/isl/ion_schema_1_0/type.isl
+++ b/isl/ion_schema_1_0/type.isl
@@ -1,0 +1,88 @@
+schema_header::{
+  imports: [
+    { id: "isl/ion_schema_1_0/annotations.isl",         type: annotations },
+    { id: "isl/ion_schema_1_0/byte_length.isl",         type: byte_length },
+    { id: "isl/ion_schema_1_0/codepoint_length.isl",    type: codepoint_length },
+    { id: "isl/ion_schema_1_0/container_length.isl",    type: container_length },
+    { id: "isl/ion_schema_1_0/contains.isl",            type: contains },
+    { id: "isl/ion_schema_1_0/content.isl",             type: content },
+    { id: "isl/ion_schema_1_0/occurs.isl",              type: occurs },
+    { id: "isl/ion_schema_1_0/precision.isl",           type: precision },
+    { id: "isl/ion_schema_1_0/regex.isl",               type: regex },
+    { id: "isl/ion_schema_1_0/scale.isl",               type: scale },
+    { id: "isl/ion_schema_1_0/timestamp_offset.isl",    type: timestamp_offset },
+    { id: "isl/ion_schema_1_0/timestamp_precision.isl", type: timestamp_precision },
+    { id: "isl/ion_schema_1_0/valid_values.isl",        type: valid_values },
+  ],
+}
+
+type::{
+  name: type_name,
+  type: symbol,
+}
+
+type::{
+  name: type_inline,
+  type: struct,
+  fields: {
+    all_of:              list_of_type_references,
+    annotations:         annotations,
+    any_of:              list_of_type_references,
+    byte_length:         byte_length,
+    codepoint_length:    codepoint_length,
+    container_length:    container_length,
+    contains:            contains,
+    content:             content,
+    element:             type_reference,
+    fields:              { type: struct, element: type_reference },
+    not:                 type_reference,
+    occurs:              occurs,
+    one_of:              list_of_type_references,
+    ordered_elements:    list_of_type_references,
+    precision:           precision,
+    regex:               regex,
+    scale:               scale,
+    timestamp_offset:    timestamp_offset,
+    timestamp_precision: timestamp_precision,
+    type:                type_reference,
+    valid_values:        valid_values,
+  },
+}
+
+type::{
+  name: type,
+  type: type_inline,
+  annotations: required::[type],
+  fields: {
+    name: { type: symbol, occurs: required },
+  },
+}
+
+type::{
+  name: type_import_inline,
+  type: struct,
+  fields: {
+    id: { type: string, occurs: required },
+    type: { type: symbol, occurs: required },
+  },
+  annotations: [nullable],
+}
+
+type::{
+  name: type_reference,
+  any_of: [
+    type_name,
+    type_inline,
+    type_import_inline,
+  ],
+  annotations: [nullable],
+}
+
+type::{
+  name: list_of_type_references,
+  type: list,
+  element: type_reference,
+}
+
+schema_footer::{
+}

--- a/isl/ion_schema_1_0/valid_values.isl
+++ b/isl/ion_schema_1_0/valid_values.isl
@@ -1,0 +1,49 @@
+schema_header::{
+}
+
+type::{
+  name: range_boundary_number,
+  type: number,
+  annotations: [exclusive],
+}
+
+type::{
+  name: range_number,
+  type: list,
+  annotations: required::[range],
+  ordered_elements: [
+    { one_of: [ range_boundary_number, { valid_values: [min] } ] },
+    { one_of: [ range_boundary_number, { valid_values: [max] } ] },
+  ],
+  container_length: 2,
+}
+
+type::{
+  name: range_boundary_timestamp,
+  type: timestamp,
+  annotations: [exclusive],
+}
+
+type::{
+  name: range_timestamp,
+  type: list,
+  annotations: required::[range],
+  ordered_elements: [
+    { one_of: [ range_boundary_timestamp, { valid_values: [min] } ] },
+    { one_of: [ range_boundary_timestamp, { valid_values: [max] } ] },
+  ],
+  container_length: 2,
+}
+
+type::{
+  name: valid_values,
+  type: list,
+  any_of: [
+    { type: list, element: $any },
+    range_number,
+    range_timestamp,
+  ],
+}
+
+schema_footer::{
+}


### PR DESCRIPTION
**Issue #, if available:**

#6

**Description of changes:**

* Copies all Ion Schema 1.0 schema files from `isl/` to `isl/ion_schema_1_0/`, updating all schema imports in the process
* Adds `isl/ion_schema_1_0.isl` containing `schema`, `schema_header`, `schema_footer`, `named_type_definition`, and `inline_type_definition` which are links/references to the respective types in `isl/ion_schema_1_0/*.isl`.
* Adds `isl/ion_schema.isl` containing `schema`, `schema_header`, `schema_footer`, `named_type_definition`, and `inline_type_definition` which are set up to each be a union of multiple versions of these types.
* Updates `README.md` to describe this new system of organization.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
