### PR TITLE
Adds utf8_byte_length and some minor fixes to ISL for Ion Schema 1.0

### DIFF
--- a/isl/ion_schema_1_0/non_negative_int.isl
+++ b/isl/ion_schema_1_0/non_negative_int.isl
@@ -18,5 +18,6 @@ type::{
     { one_of: [ range_boundary_non_negative_int, { valid_values: [min] } ] },
     { one_of: [ range_boundary_non_negative_int, { valid_values: [max] } ] },
   ],
+  not: { contains: [min, max]},
   container_length: 2,
 }

--- a/isl/ion_schema_1_0/precision.isl
+++ b/isl/ion_schema_1_0/precision.isl
@@ -21,6 +21,7 @@ type::{
     { one_of: [ range_boundary_positive_int, { valid_values: [min] } ] },
     { one_of: [ range_boundary_positive_int, { valid_values: [max] } ] },
   ],
+  not: { contains: [min, max] },
   container_length: 2,
 }
 

--- a/isl/ion_schema_1_0/timestamp_offset.isl
+++ b/isl/ion_schema_1_0/timestamp_offset.isl
@@ -1,8 +1,9 @@
 type::{
   name: timestamp_offset,
   type: list,
+  container_length: range::[1, max],
   element: {
     type: string,
-    regex: "^[+|-][0-2][0-9]:[0-5][0-9]$",
+    regex: "^[+|-]([01][0-9]|2[0-3]):[0-5][0-9]$",
   },
 }

--- a/isl/ion_schema_1_0/type.isl
+++ b/isl/ion_schema_1_0/type.isl
@@ -12,6 +12,7 @@ schema_header::{
     { id: "isl/ion_schema_1_0/scale.isl",               type: scale },
     { id: "isl/ion_schema_1_0/timestamp_offset.isl",    type: timestamp_offset },
     { id: "isl/ion_schema_1_0/timestamp_precision.isl", type: timestamp_precision },
+    { id: "isl/ion_schema_1_0/utf8_byte_length.isl",    type: utf8_byte_length },
     { id: "isl/ion_schema_1_0/valid_values.isl",        type: valid_values },
   ],
 }
@@ -34,7 +35,7 @@ type::{
     contains:            contains,
     content:             content,
     element:             type_reference,
-    fields:              { type: struct, element: type_reference },
+    fields:              { type: struct, element: type_reference, container_length: range::[1, max] },
     not:                 type_reference,
     occurs:              occurs,
     one_of:              list_of_type_references,
@@ -45,6 +46,7 @@ type::{
     timestamp_offset:    timestamp_offset,
     timestamp_precision: timestamp_precision,
     type:                type_reference,
+    utf8_byte_length:    utf8_byte_length,
     valid_values:        valid_values,
   },
 }
@@ -75,6 +77,7 @@ type::{
     type_inline,
     type_import_inline,
   ],
+  not: { valid_values: [document], annotations: required::[nullable] },
   annotations: [nullable],
 }
 

--- a/isl/ion_schema_1_0/utf8_byte_length.isl
+++ b/isl/ion_schema_1_0/utf8_byte_length.isl
@@ -5,11 +5,10 @@ schema_header::{
 }
 
 type::{
-  name: occurs,
+  name: utf8_byte_length,
   one_of: [
-    { type: int, valid_values: range::[1, max] },
+    non_negative_int,
     range_non_negative_int,
-    { valid_values: [optional, required] },
   ],
 }
 

--- a/isl/ion_schema_1_0/valid_values.isl
+++ b/isl/ion_schema_1_0/valid_values.isl
@@ -15,12 +15,14 @@ type::{
     { one_of: [ range_boundary_number, { valid_values: [min] } ] },
     { one_of: [ range_boundary_number, { valid_values: [max] } ] },
   ],
+  not: { contains: [min, max] },
   container_length: 2,
 }
 
 type::{
   name: range_boundary_timestamp,
   type: timestamp,
+  not: { timestamp_offset: ["-00:00"] },
   annotations: [exclusive],
 }
 
@@ -32,14 +34,26 @@ type::{
     { one_of: [ range_boundary_timestamp, { valid_values: [min] } ] },
     { one_of: [ range_boundary_timestamp, { valid_values: [max] } ] },
   ],
+  not: { contains: [min, max] },
   container_length: 2,
 }
 
 type::{
   name: valid_values,
   type: list,
-  any_of: [
-    { type: list, element: $any },
+  one_of: [
+    {
+      type: list,
+      annotations: closed::[],
+      element: {
+        type: $any,
+        one_of: [
+          { type: $any, annotations: closed::[] },
+          range_number,
+          range_timestamp,
+        ]
+      }
+    },
     range_number,
     range_timestamp,
   ],


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

* Adds `utf8_byte_length` in ISL for ISL 1.0
* Sets the minimum `occurs` single value to `1`. (A range can still have `0` as the lower bound.) This is consistent with the spec and the Kotlin implementation.
* Updates the `timestamp_offset` regex so that it only allows valid timestamp offsets.
* Updates `fields` to require a non-empty struct
* Updates `valid_values` so that non-range values may not be annotated
* Updates all ranges to prohibit `range::[min, max]`
* Updates timestamp ranges to require a known local offset
* Prohibits `document` from being annotated with `nullable`


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
